### PR TITLE
Replace PositionFirstComponent by PositionSorted

### DIFF
--- a/lib/BibXMLextTools.gi
+++ b/lib/BibXMLextTools.gi
@@ -1343,7 +1343,7 @@ end);
 AddHandlerBuildRecBibXMLEntry("value", "default",
 function(entry, elt, default, strings, opts)
   local pos;
-  pos := PositionFirstComponent(strings, elt.attributes.key);
+  pos := PositionSorted(strings, [elt.attributes.key]);
   if not IsBound(strings[pos]) or strings[pos][1] <> elt.attributes.key then
     return Concatenation("UNKNOWNVALUE(", elt.attributes.key, ")");
   else


### PR DESCRIPTION
PositionFirstComponent was deprecated in GAP 4.7.5 (May 2014)

This change to GAPDoc was originally proposed April 7, 2014.