### PR TITLE
Add optional entitydict argument to MakeGAPDocDoc

### DIFF
--- a/doc/conv.xml
+++ b/doc/conv.xml
@@ -149,7 +149,8 @@ gap> GAPDoc2HTMLPrintHTMLFiles(h, path);
 </Log>
 
 <ManSection >
-<Func Arg="path, main, files, bookname[, gaproot]" Name="MakeGAPDocDoc" />
+<Func Arg="path, main, files, bookname[, gaproot][, entitydict]"
+      Name="MakeGAPDocDoc" />
 
 <Description>
 This  function  collects  all  the   commands  for  producing  a  text-,
@@ -173,7 +174,11 @@ Chapter&nbsp;<Ref Chap="Distributing"/>. And <A>bookname</A> is the name
 of  the  book  used  by  &GAP;'s  online  help.  The  optional  argument
 <A>gaproot</A>  must be  a string  which  gives the  relative path  from
 <A>path</A> to the main &GAP; root directory. If this is given, the HTML
-files are produced with relative paths to external books.<P/>
+files are produced with relative paths to external books.
+The optional argument <A>entities</A> must be a record and is passed
+unchanged to <Ref Func="ParseTreeXMLString"/>. See there for an
+explanation of what it does.
+<P/>
 
 <Index Key="MathJax" Subkey="in MakeGAPDocDoc"><Package>MathJax</Package> 
 <Subkey>in <C>MakeGAPDocDoc</C></Subkey></Index>

--- a/lib/Make.g
+++ b/lib/Make.g
@@ -12,9 +12,9 @@
 ##  
 
 ##  args: 
-##     path, main, files, bookname[, gaproot][, "MathML"][, "Tth"][, "MathJax"]
+##     path, main, files, bookname[, gaproot][, entitydict][, "MathML"][, "Tth"][, "MathJax"]
 BindGlobal("MakeGAPDocDoc", function(arg)
-  local htmlspecial, path, main, files, bookname, gaproot, str, 
+  local htmlspecial, path, main, files, bookname, gaproot, entitydict, str,
         r, t, l, latex, null, log, pos, h, i, j;
   htmlspecial := Filtered(arg, a-> a in ["MathML", "Tth", "MathJax"]);
   if Length(htmlspecial) > 0 then
@@ -24,10 +24,17 @@ BindGlobal("MakeGAPDocDoc", function(arg)
   main := arg[2];
   files := arg[3];
   bookname := arg[4];
-  if IsBound(arg[5]) then
+  gaproot := false;
+  entitydict := false;
+  if Length(arg) >= 6 then
     gaproot := arg[5];
-  else
-    gaproot := false;
+    entitydict := arg[6];
+  elif Length(arg) = 5 then
+    if IsString(arg[5]) then
+      gaproot := arg[5];
+    else
+      entitydict := arg[5];
+    fi;
   fi;
   # ensure that path is directory object
   if IsString(path) then
@@ -43,7 +50,7 @@ BindGlobal("MakeGAPDocDoc", function(arg)
                              Concatenation(main, ".xml"), files, true);
   # parse the XML document
   Info(InfoGAPDoc, 1, "#I Parsing XML document . . .\n");
-  r := ParseTreeXMLString(str[1], str[2]);
+  r := ParseTreeXMLString(str[1], str[2], entitydict);
   # clean the result
   Info(InfoGAPDoc, 1, "#I Checking XML structure . . .\n");
   CheckAndCleanGapDocTree(r);


### PR DESCRIPTION
If given, this is passed to ParseTreeXMLString unchanged. Useful for
passing custom entity values (e.g. a package version) to GAPDoc.