### PR TITLE
Replace RecFields by RecNames

### DIFF
--- a/doc/refdtd.xml
+++ b/doc/refdtd.xml
@@ -1439,7 +1439,7 @@ some not too bad representation of a formula.<P/>
 As examples, here are some  &LaTeX;  macros which have  a  sensible 
 ASCII  translation and  are
 guaranteed to be translated accordingly by text (and HTML) converters 
-(for a full list of handled Macros see <C>RecFields(TEXTMTRANSLATIONS)</C>):
+(for a full list of handled Macros see <C>RecNames(TEXTMTRANSLATIONS)</C>):
 
 <Table Align="|l|l|">
  <Caption>&LaTeX; macros with special text translation</Caption>

--- a/lib/BibTeX.gi
+++ b/lib/BibTeX.gi
@@ -943,16 +943,16 @@ InstallGlobalFunction(StringBibAsText, function(arg)
   ansi.Bib_editor := ansi.Bib_author;
   ansi.Bib_subtitle := ansi.Bib_title;
   if Length(arg) = 2  and arg[2] <> true then
-    for f in RecFields(arg[2]) do
+    for f in RecNames(arg[2]) do
       ansi.(f) := arg[2].(f);
     od;
   elif IsBound(r.From) and IsBound(r.From.options) and
             IsBound(r.From.options.ansi) then
-    for f in RecFields(r.From.options.ansi) do
+    for f in RecNames(r.From.options.ansi) do
       ansi.(f) := r.From.options.ansi.(f);
     od;
   else
-    for f in RecFields(ansi) do
+    for f in RecNames(ansi) do
       ansi.(f) := "";
     od;
   fi;
@@ -1290,7 +1290,7 @@ InstallGlobalFunction(SearchMRBib, function(arg)
     fi;
   else
     a := ShallowCopy(a);
-    for f in RecFields(a) do
+    for f in RecNames(a) do
       if IsString(a.(f)) then
         a.(f) := HeuristicTranslationsLaTeX2XML.Apply(a.(f));
       fi;

--- a/lib/BibXMLextTools.gi
+++ b/lib/BibXMLextTools.gi
@@ -114,7 +114,7 @@ BibXMLextStructure.fill();
 InstallGlobalFunction(TemplateBibXML, function(arg)
   local type, res, add, a, b;
   if Length(arg) = 0 then
-    return Filtered(RecFields(BibXMLextStructure), a-> not a in ["fill"]);
+    return Filtered(RecNames(BibXMLextStructure), a-> not a in ["fill"]);
   fi;
   type := arg[1];
   if type = "fill" or not IsBound(BibXMLextStructure.(type)) then
@@ -209,7 +209,7 @@ end);
 ##  
 ##  <Example>
 ##  gap> bib := ParseBibXMLextFiles("doc/testbib.xml");;
-##  gap> RecFields(bib);
+##  gap> RecNames(bib);
 ##  [ "entries", "strings", "entities" ]
 ##  gap> bib.entries;
 ##  [ &lt;BibXMLext entry: AB2000> ]
@@ -253,7 +253,7 @@ InstallGlobalFunction(ParseBibXMLextString, function(arg)
   fi;
   tr := ParseTreeXMLString(str, ENTITYDICT_bibxml);
   # get used entities from ENTITYDICT
-  ent := List(RecFields(ENTITYDICT), a-> [a, ENTITYDICT.(a)]);
+  ent := List(RecNames(ENTITYDICT), a-> [a, ENTITYDICT.(a)]);
   Append(res.entities, ent);
   res.entities := Set(res.entities);
 
@@ -401,7 +401,7 @@ InstallGlobalFunction(StringBibAsXMLext,  function(arg)
     enc := arg[Length(arg)];
   else
     # try to autodetect UTF-8, else assume latin1
-    if ForAny(RecFields(r), a-> IsString(r.(a)) and Unicode(r.(a)) = fail) or
+    if ForAny(RecNames(r), a-> IsString(r.(a)) and Unicode(r.(a)) = fail) or
        ForAny(abbrevs, a-> Unicode(a) = fail) or
        ForAny(texts, a-> Unicode(a) = fail) then
       enc := "ISO-8859-1";
@@ -417,7 +417,7 @@ InstallGlobalFunction(StringBibAsXMLext,  function(arg)
   fi;
   if enc <> "UTF-8" then
     r := ShallowCopy(r);
-    for a in RecFields(r) do
+    for a in RecNames(r) do
       if IsString(r.(a)) then
         r.(a) := Encode(Unicode(r.(a), enc));
       fi;
@@ -456,14 +456,14 @@ InstallGlobalFunction(StringBibAsXMLext,  function(arg)
     od;
     return ParseTreeXMLString(res).content;
   end;
-  if not (r.Type in RecFields(BibXMLextStructure)) then
+  if not (r.Type in RecNames(BibXMLextStructure)) then
     Info(InfoBibTools, 1, "#W WARNING: invalid .Type in Bib-record: ",
                                                           r.Type, "\n");
     Info(InfoBibTools, 2, r, "\n");
     return fail;
   fi;
   struct := BibXMLextStructure.(r.Type);
-  f := RecFields(r);
+  f := RecNames(r);
 
   if "Label" in f then
     lbl:= Concatenation( " (", r.Label, ") " );
@@ -1109,7 +1109,7 @@ function(entry, elt, type, strings, opts)
     res := rec(From := rec(BibXML := true, type := type, options := opts));
     res.Label := entry.attributes.id;
     f := First(entry.content, a-> IsRecord(a) and a.name in
-                                             RecFields(BibXMLextStructure));
+                                             RecNames(BibXMLextStructure));
     res.Type := f.name;
     for a in f.content do
       if IsRecord(a) and not a.name = "PCDATA" then

--- a/lib/ComposeXML.gi
+++ b/lib/ComposeXML.gi
@@ -246,7 +246,7 @@ InstallGlobalFunction(ComposedDocument, function(arg)
   # now start the recursion as #Include of the main file in empty string
   Collect(res, src, NormalizedFilename(main), 0);
   Info(InfoGAPDoc, 2, "#I Labels of chunks which were not used: ",
-                      Difference(RecFields(pieces), usedpieces), "\n");
+                      Difference(RecNames(pieces), usedpieces), "\n");
   if info then
     return [res, src];
   else

--- a/lib/Examples.gi
+++ b/lib/Examples.gi
@@ -400,7 +400,7 @@ InstallGlobalFunction(RunExamples, function(arg)
   );                 
   nodiffs := true;
   if Length(arg) > 1 and IsRecord(arg[2]) then
-    for a in RecFields(arg[2]) do
+    for a in RecNames(arg[2]) do
       opts.(a) := arg[2].(a);
     od;
   fi;

--- a/lib/GAPDoc2LaTeX.gi
+++ b/lib/GAPDoc2LaTeX.gi
@@ -256,14 +256,14 @@ GAPDoc2LaTeXProcs.HeadWithOptions := function(extra)
   local head, opt, f, ff;
   head := GAPDoc2LaTeXProcs.Head;
   opt := GAPDoc2LaTeXProcs.Options;
-  for f in RecFields(opt) do
+  for f in RecNames(opt) do
     if f = "ColorDefinitions" then
-      for ff in RecFields(opt.(f)) do
+      for ff in RecNames(opt.(f)) do
         head := SubstitutionSublist(head, 
                                Concatenation("CONFIGCOLOR",ff), opt.(f).(ff));
       od;
     elif f = "HyperrefOptions" then
-      for ff in RecFields(opt.(f)) do
+      for ff in RecNames(opt.(f)) do
         head := SubstitutionSublist(head, 
                                Concatenation("CONFIGHR",ff), opt.(f).(ff));
       od;
@@ -309,10 +309,10 @@ SetGapDocLaTeXOptions := function(arg)
 
   # now overwrite the defaults
   for r in recs do
-    for f in RecFields(r) do
+    for f in RecNames(r) do
       if IsRecord(r.(f)) then
         if IsBound(new.(f)) then
-          for ff in RecFields(r.(f)) do
+          for ff in RecNames(r.(f)) do
             if IsBound(new.(f).(ff)) then
               new.(f).(ff) := r.(f).(ff);
             fi;

--- a/lib/Text.gi
+++ b/lib/Text.gi
@@ -842,7 +842,7 @@ InstallGlobalFunction(SubstituteEscapeSequences, function(str, subs)
     else
       orig := subs;
       subs := ShallowCopy(subs);
-      for a in RecFields(subs) do
+      for a in RecNames(subs) do
         if IsList(subs.(a)) then
           subs.(a) := [subs.(a)[1], List(subs.(a)[2], x-> 
                                 Encode(

--- a/lib/TextThemes.g
+++ b/lib/TextThemes.g
@@ -143,7 +143,7 @@ GAPDoc2TextProcs.f := function()
   local dt, a;
   dt := GAPDoc2TextProcs.OtherThemes.default;
   # most empty, some copied from default
-  for a in RecFields(dt) do
+  for a in RecNames(dt) do
     GAPDoc2TextProcs.OtherThemes.none.(a) := "";
   od;
   for a in ["Q", "DefLineMarker", "ListBullet", "FillString", "EnumMarks"] do
@@ -191,18 +191,18 @@ InstallGlobalFunction(SetGAPDocTextTheme, function(arg)
       if not IsBound(GAPDoc2TextProcs.OtherThemes.(a)) then
         Print("Only the following named text themes are available \
 (choose one or several):\n");
-        for nam in RecFields(GAPDoc2TextProcs.OtherThemes) do
+        for nam in RecNames(GAPDoc2TextProcs.OtherThemes) do
           Print("  ",String(Concatenation("\"",nam,"\""), -25),
                 GAPDoc2TextProcs.OtherThemes.(nam).info, "\n");
         od;
         return;
       else
-        for f in RecFields(GAPDoc2TextProcs.OtherThemes.(a)) do
+        for f in RecNames(GAPDoc2TextProcs.OtherThemes.(a)) do
           r.(f) := GAPDoc2TextProcs.OtherThemes.(a).(f);
         od;
       fi;
     else
-      for f in RecFields(a) do
+      for f in RecNames(a) do
         r.(f) := a.(f);
       od;
     fi;
@@ -235,7 +235,7 @@ InstallGlobalFunction(SetGAPDocTextTheme, function(arg)
     res.(af[i]) := [[h[1][2*i-1], h[1][2*i]],[h[2][2*i-1], h[2][2*i]]];
   od;
   SortParallel(h[1], h[2]);
-  for f in RecFields(res) do
+  for f in RecNames(res) do
     GAPDocTextTheme.(f) := res.(f);
   od;
 end);

--- a/lib/UnicodeTools.gi
+++ b/lib/UnicodeTools.gi
@@ -61,7 +61,7 @@ UNICODE_RECODE.f := function()
 
   UNICODE_RECODE.NormalizedEncodings.("UTF-8") := "UTF-8";
   UNICODE_RECODE.NormalizedEncodings.("XML") := "XML";
-  for nam in RecFields(UNICODE_RECODE.NormalizedEncodings) do
+  for nam in RecNames(UNICODE_RECODE.NormalizedEncodings) do
     UNICODE_RECODE.NormalizedEncodings.(LowercaseString(nam)) :=
               UNICODE_RECODE.NormalizedEncodings.(nam);
   od;
@@ -569,7 +569,7 @@ InstallMethod(Unicode, [IsString, IsString], function(str, enc)
   fi;
   if not IsBound(UNICODE_RECODE.NormalizedEncodings.(enc)) then
     Error("Sorry, only the following encodings are supported for 'Unicode':\n",
-              RecFields(UNICODE_RECODE.Decoder), "\n");
+              RecNames(UNICODE_RECODE.Decoder), "\n");
   fi;
   enc := UNICODE_RECODE.NormalizedEncodings.(enc);
   res := UNICODE_RECODE.Decoder.(enc)(str);
@@ -1057,7 +1057,7 @@ end;
 InstallMethod(Encode, [IsUnicodeString, IsString], function(ustr, enc)
   if not IsBound(UNICODE_RECODE.NormalizedEncodings.(enc)) then
     Error("Sorry, only the following encodings are supported for Encode:\n",
-                    RecFields(UNICODE_RECODE.Encoder), "\n");
+                    RecNames(UNICODE_RECODE.Encoder), "\n");
   fi;
   enc := UNICODE_RECODE.NormalizedEncodings.(enc);
   return UNICODE_RECODE.Encoder.(enc)(ustr);
@@ -1067,7 +1067,7 @@ InstallOtherMethod(Encode, [IsUnicodeString, IsString, IsObject],
 function(ustr, enc, data)
   if not IsBound(UNICODE_RECODE.NormalizedEncodings.(enc)) then
     Error("Sorry, only the following encodings are supported for Encode:\n",
-                    RecFields(UNICODE_RECODE.Encoder), "\n");
+                    RecNames(UNICODE_RECODE.Encoder), "\n");
   fi;
   enc := UNICODE_RECODE.NormalizedEncodings.(enc);
   return UNICODE_RECODE.Encoder.(enc)(ustr, data);

--- a/lib/XMLParser.gi
+++ b/lib/XMLParser.gi
@@ -514,7 +514,7 @@ InstallGlobalFunction(GetElement, function(str, pos)
           ##  GAPDoc defined entities automatically
           pos := PositionSublist(dt.content, "gapdoc.dtd");
           if pos <> fail and dt.content[pos-1] in "'\"/" then
-            for p in RecFields(ENTITYDICT_GAPDoc) do
+            for p in RecNames(ENTITYDICT_GAPDoc) do
               ENTITYDICT.(p) := ENTITYDICT_GAPDoc.(p);
             od;
           fi;
@@ -685,16 +685,16 @@ InstallGlobalFunction(ParseTreeXMLString, function(arg)
     XMLPARSEORIGINS := false;
   fi;
   # reset ENTITYDICT
-  for a in RecFields(ENTITYDICT) do
+  for a in RecNames(ENTITYDICT) do
     Unbind(ENTITYDICT.(a));
   od;
-  for a in RecFields(ENTITYDICT_default) do
+  for a in RecNames(ENTITYDICT_default) do
     ENTITYDICT.(a) := ENTITYDICT_default.(a);
   od;
   # maybe load more entities from last argument
   if Length(arg) > 1 and IsRecord(arg[Length(arg)]) then
     ents := arg[Length(arg)];
-    for a in RecFields(ents) do
+    for a in RecNames(ents) do
       ENTITYDICT.(a) := ents.(a);
     od;
   fi;
@@ -898,7 +898,7 @@ StringXMLElement := function(arg)
   p := [Length(str)+1];
   Append(str, "<");
   Append(str, r.name);
-  for att in RecFields(r.attributes) do
+  for att in RecNames(r.attributes) do
     Add(str, ' ');
     Append(str, att);
     Append(str, "=\"");
@@ -966,7 +966,7 @@ EntitySubstitution := function(xmlstr, entities)
     posinfo := fail;
   fi;
   if IsRecord(entities) then
-    entities := List(RecFields(entities), f-> [f, entities.(f)]);
+    entities := List(RecNames(entities), f-> [f, entities.(f)]);
   fi;
   # parse and rewrite entities
   entities2 := List(entities, a-> [a[1], StringXMLElement(

--- a/lib/parsedtd.g
+++ b/lib/parsedtd.g
@@ -21,9 +21,9 @@ while pos <> fail do
 od;
 
 # substitute entities
-while ForAny(RecFields(entities), a-> PositionSublist(dtd,
+while ForAny(RecNames(entities), a-> PositionSublist(dtd,
                                             Concatenation("%",a)) <> fail) do
-  for a in RecFields(entities) do
+  for a in RecNames(entities) do
     dtd := SubstitutionSublist(dtd, Concatenation("%",a,";"), entities.(a));
   od;
 od;


### PR DESCRIPTION
RecFields was the name under GAP 3, but in GAP 4 it is not documented.