### PR TITLE
Use 'InfoOutput' to get Info output stream

### DIFF
--- a/init.g
+++ b/init.g
@@ -10,12 +10,17 @@
 # An alternative Info handler which does not print implicit "#I " and "\n"
 BindGlobal("PlainInfoHandler",
 function ( infoclass, level, list )
-    local cl, out, s;
-    cl := InfoData.LastClass![1];
-    if IsBound(InfoData.Output[cl]) then
-      out := InfoData.Output[cl];
+    local cl, out, s, infoOutput;
+    if IsBoundGlobal("InfoOutput") then
+      infoOutput := ValueGlobal("InfoOutput");
+      out := infoOutput(infoclass);
     else
-      out := DefaultInfoOutput;
+      cl := InfoData.LastClass![1];
+      if IsBound(InfoData.Output[cl]) then
+        out := InfoData.Output[cl];
+      else
+        out := DefaultInfoOutput;
+      fi;
     fi;
     if out = "*Print*" then
       for s in list do


### PR DESCRIPTION
This PR uses the new function `InfoOutput` to get the value of the output stream.

The reason for this (as well as making the code hopefully cleaner) is that I would like to change the internal data structures used by `Info` to make them more efficient.