### PR TITLE
Use MATCH_BEGIN_COUNT to rank help matches

### DIFF
--- a/lib/HelpBookHandler.g
+++ b/lib/HelpBookHandler.g
@@ -232,18 +232,26 @@ HELP_BOOK_HANDLER.GapDocGAP.ShowSections :=
 #  very similar to the .default handler, but we allow search for
 #  (sub-)section numbers as well
 HELP_BOOK_HANDLER.GapDocGAP.SearchMatches := function (book, topic, frombegin)
-  local   info,  exact,  match,  i;
+  local   info,  exact,  match,  rank,  m,  i;
   
   info := HELP_BOOK_INFO(book);
   exact := [];
   match := [];
+  rank := [];
   for i in [1..Length(info.entries)] do
     if topic=info.entries[i][6] or topic=info.entries[i][2] then
       Add(exact, i);
     elif frombegin = true then
-      if MATCH_BEGIN(info.entries[i][6], topic) or 
-         MATCH_BEGIN(info.entries[i][2], topic) then
+      m := MATCH_BEGIN_COUNT(info.entries[i][6], topic);
+      if m >= 0 then
         Add(match, i);
+        Add(rank, -m);
+      else
+        m := MATCH_BEGIN_COUNT(info.entries[i][2], topic);
+        if m >= 0 then
+          Add(match, i);
+          Add(rank, -m);
+        fi;
       fi;
     else
       if IS_SUBSTRING(info.entries[i][6], topic) then
@@ -251,6 +259,12 @@ HELP_BOOK_HANDLER.GapDocGAP.SearchMatches := function (book, topic, frombegin)
       fi;
     fi;
   od;
+
+  # sort by rank if applicable
+  if frombegin = true then
+    SortParallel(rank, match);
+  fi;
+
 ##    HELP_BOOK_HANDLER.GapDocGAP.setTextTheme();
   HELP_BOOK_HANDLER.GapDocGAP.apptheme(info, GAPDocTextTheme);
 


### PR DESCRIPTION
This PR addresses <https://github.com/gap-system/gap/issues/2051> Without this PR, I get this when entering `?Int`:
```
[1] Reference: Int
[2] Reference: Integers
[3] Reference: Integers: Global Variables
[4] Reference: Internally Represented Cyclotomics
[5] Reference: Interval-specific methods
[6] Reference: IntersectionBlist
[7] Reference: Integral matrices and lattices
[8] Reference: Internally Represented Strings
[9] Reference: Intersection
[10] Reference: Integral Bases of Abelian Number Fields
[11] Reference: Interface to the GAP Help System
[12] Reference: Introducing new Viewer for the Online Help
[13] Reference: Internal representation of ordered partitions
[14] Reference: Integers global variable
[15] Reference: integer part of a quotient
[16] Reference: Int for a cyclotomic
[17] Reference: IntersectSet
[18] Reference: intersection of sets
[19] Reference: IntersectionBlist for various boolean lists
[20] Reference: IntersectionBlist for a list
[21] Reference: IntersectBlist
[22] Reference: IntegralizedMat
[23] Reference: IntChar
[24] Reference: Int for strings
[25] Reference: IntHexString
[26] Reference: Intersection for various collections
[27] Reference: Intersection for a list
[28] Reference: Intersection2
[29] Reference: intersection of collections
[30] Reference: IntegratedStraightLineProgram
[31] Reference: IntermediateResultOfSLP
[32] Reference: IntermediateResultOfSLPWithoutOverwrite
[33] Reference: IntermediateResultsOfSLPWithoutOverwrite
[34] Reference: IntermediateGroup
[35] Reference: IntermediateSubgroups
[36] Reference: Intersection for groups with pcgs
[37] Reference: InterpolatedPolynomial
[38] Reference: IntFFE
[39] Reference: Int for a ffe
[40] Reference: IntFFESymm for a ffe
[41] Reference: IntFFESymm for a vector of ffes
[42] Reference: IntVecFFE
[43] Reference: IntersectionsTom
[44] Reference: IntScalarProducts
...
```
Note entries 1, 16, 24 and 39 all are for variants of `Int`.

With this PR, I get this:
```
[1] Reference: Int
[2] Reference: Int for a cyclotomic
[3] Reference: Int for a ffe
[4] Reference: Int for strings
[5] Reference: Integers
[6] Reference: Internally Represented Cyclotomics
[7] Reference: Interval-specific methods
[8] Reference: IntersectionBlist
[9] Reference: Integral matrices and lattices
...
```

I.e. the four entries for `Int` variants are all at the top.