### PR TITLE
Fix using type="html" in SearchMR

### DIFF
--- a/lib/BibTeX.gi
+++ b/lib/BibTeX.gi
@@ -1277,6 +1277,9 @@ InstallGlobalFunction(SearchMR, function(r)
   Append(uri, "&extend=1");
   uri := Concatenation("https://",SEARCHMRHOST,uri);
   res := GetByWgetOrCurl(uri);
+  if r.type <> "bibtex" then
+    return res;
+  fi;
   i := PositionSublist(res, "<pre>\n@");
   extr := [];
   while i <> fail do


### PR DESCRIPTION
The documentation for `SearchMR` says
```
##  Furthermore, the component <C>type</C> can be specified. It can be one of 
##  <C>"bibtex"</C> (the default if not given), <C>"pdf"</C>, <C>"html"</C> and
##  probably others. In the last  cases the function returns a string with
##  the correspondig PDF-file or web page from <Package>MathSciNet</Package>.
```
However, with `type="html"` it returns an empty list. This makes it working, and closes #31. 