### PR TITLE
Remove use of STRING_LOWER

### DIFF
--- a/lib/BibTeX.gi
+++ b/lib/BibTeX.gi
@@ -199,7 +199,7 @@ InstallGlobalFunction(NormalizedNameAndKey, function(str)
       else
         Add(keyshort, 'X');
       fi;
-      Append(keylong, STRING_LOWER(Filtered(a[1]{[p..Length(a[1])]},
+      Append(keylong, LowercaseString(Filtered(a[1]{[p..Length(a[1])]},
               x-> x in LETTERS)));
     fi;
   od;

--- a/lib/GAPDoc.gi
+++ b/lib/GAPDoc.gi
@@ -296,7 +296,7 @@ InstallGlobalFunction(PrintSixFile, function(file, r, bookname)
   f := function(a)
     local   res;
     res := ShallowCopy(a);
-    res[2] := STRING_LOWER(res[2]);
+    res[2] := LowercaseString(res[2]);
     return res;
   end;
   PrintTo(file, "#SIXFORMAT  GapDocGAP\nHELPBOOKINFOSIXTMP := rec(\n",

--- a/lib/GAPDoc2HTML.gi
+++ b/lib/GAPDoc2HTML.gi
@@ -713,7 +713,7 @@ GAPDoc2HTMLProcs.WHOLEDOCUMENT := function(r, par)
   # .index has entries of form [sorttext, subsorttext, numbertext, 
   # entrytext, url[, subtext]]
   Info(InfoGAPDoc, 1, "#I Producing the index . . .\n");
-  SortBy(r.index, a-> [a[1],STRING_LOWER(a[2]),
+  SortBy(r.index, a-> [a[1],LowercaseString(a[2]),
                        List(SplitString(a[3],".-",""), Int)]);
   str := "";
   ind := r.index;
@@ -1519,9 +1519,9 @@ GAPDoc2HTMLProcs.Index := function(r, str)
   NormalizeWhitespace(s);
   NormalizeWhitespace(sub);
   if IsBound(r.attributes.Key) then
-    entry := [STRING_LOWER(r.attributes.Key)];
+    entry := [LowercaseString(r.attributes.Key)];
   else
-    entry := [STRING_LOWER(s)];
+    entry := [LowercaseString(s)];
   fi;
   if IsBound(r.attributes.Subkey) then
     Add(entry, r.attributes.Subkey);
@@ -1581,7 +1581,7 @@ GAPDoc2HTMLProcs.LikeFunc := function(r, par, typ)
   else
     lab := "";
   fi;
-  Add(r.root.index, [STRING_LOWER(name), lab, 
+  Add(r.root.index, [LowercaseString(name), lab, 
           GAPDoc2HTMLProcs.SectionNumber(r.count, "Subsection"), 
           Concatenation(attr[1], name, attr[2]),
           url]);

--- a/lib/GAPDoc2Text.gi
+++ b/lib/GAPDoc2Text.gi
@@ -555,7 +555,7 @@ GAPDoc2TextProcs.WHOLEDOCUMENT := function(r, par)
   # .index has entries of form [sorttext, subsorttext, numbertext, 
   #  entrytext, count[, subtext]]
   Info(InfoGAPDoc, 1, "#I Producing the index . . .\n");
-  SortBy(r.index, a-> [a[1],STRING_LOWER(a[2]),
+  SortBy(r.index, a-> [a[1],LowercaseString(a[2]),
                        List(SplitString(a[3],".-",""), Int)]);
   str := "";
   ind := r.index;
@@ -1340,14 +1340,14 @@ GAPDoc2TextProcs.Index := function(r, str)
   NormalizeWhitespace(s);
   NormalizeWhitespace(sub);
   if IsBound(r.attributes.Key) then
-    entry := [STRING_LOWER(r.attributes.Key)];
+    entry := [LowercaseString(r.attributes.Key)];
   else
-    entry := [STRING_LOWER(StripEscapeSequences(s))];
+    entry := [LowercaseString(StripEscapeSequences(s))];
   fi;
   if IsBound(r.attributes.Subkey) then
     Add(entry, r.attributes.Subkey);
   else
-    Add(entry, STRING_LOWER(StripEscapeSequences(sub)));
+    Add(entry, LowercaseString(StripEscapeSequences(sub)));
   fi;
   Add(entry, GAPDoc2TextProcs.SectionNumber(r.count, "Subsection"));
   Add(entry, s);
@@ -1405,12 +1405,12 @@ GAPDoc2TextProcs.LikeFunc := function(r, par, typ)
        := Concatenation(r.attributes.Name, comma, lab)), root := r.root), par);
   # index entry
   name := r.attributes.Name;
-  entry := [STRING_LOWER(name), "", 
+  entry := [LowercaseString(name), "", 
             GAPDoc2TextProcs.SectionNumber(r.count, "Subsection"), 
             WrapTextAttribute(name, GAPDoc2TextProcs.TextAttr.Func),
             r.count{[1..3]}];
   if Length(lab) > 0 then
-    entry[2] := STRING_LOWER(StripEscapeSequences(lab));
+    entry[2] := LowercaseString(StripEscapeSequences(lab));
     Add(entry, lab);
   fi;
   Add(r.root.index, entry);


### PR DESCRIPTION
It can safely be replaced by `LowercaseString`, and would allow removing `STRING_LOWER` from GAP.