### PR TITLE
PackageInfo.g: add alternative archive formats

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -21,7 +21,7 @@ SourceRepository := rec(
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
 ArchiveURL := 
           "http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/GAPDoc-1.6.2",
-ArchiveFormats := ".tar.bz2",
+ArchiveFormats := ".tar.bz2 .tar.gz -win.zip",
 Persons := [
   rec(
   LastName := "Lübeck",


### PR DESCRIPTION
GAPDoc provides downloads in `.tar.bz2`, `.tar.gz` and `-win.zip` formats, but only advertises the first of these in its PackageInfo.g file.

The Example package suggests that any number of formats can be specified in `ArchiveFormats`, separated by spaces or commas.

This pull request adds `.tar.gz` and `-win.zip` to `ArchiveFormats`, so that automated tools can retrieve their preferred format (I just tripped up on this while working on a new PackageManager feature).