### PR TITLE
Avoid InstallValue for non-plain objects

### DIFF
--- a/lib/PrintUtil.gd
+++ b/lib/PrintUtil.gd
@@ -12,7 +12,6 @@
 
 ##  a filter for a bit tricky objects
 DeclareFilter("IsObjToBePrinted");
-DeclareGlobalVariable("DUMMYTBPTYPE");
 
 DeclareGlobalFunction("PrintTo1");
 DeclareGlobalFunction("AppendTo1");

--- a/lib/PrintUtil.gi
+++ b/lib/PrintUtil.gi
@@ -11,7 +11,7 @@
 ##  
 
 ##  a hack: type for objects which only exist to print something
-InstallValue(DUMMYTBPTYPE, NewType(NewFamily(""), IsObjToBePrinted));
+BindGlobal("DUMMYTBPTYPE", NewType(NewFamily(""), IsObjToBePrinted));
 
 
 InstallMethod(PrintObj, "IsObjToBePrinted", true, [IsObjToBePrinted], 0, 


### PR DESCRIPTION
InstallValue is one of a tiny handful of places calling the GAP kernel
function CLONE_OBJ. This function is rather dangerous, e.g. for *types* it is
not really well-defined, see https://github.com/gap-system/gap/issues/1637.
While I am not aware of any ill-effects of the usage here, I think it is best
to avoid it (and perhaps we can at some point even phase out support for
`InstallValue` used on non-plain objects)
