### PR TITLE
Update to MathJax 2.7.9

### DIFF
--- a/lib/GAPDoc2HTML.gi
+++ b/lib/GAPDoc2HTML.gi
@@ -117,7 +117,7 @@ GAPDoc2HTMLProcs.Head1 := "\
 <head>\n\
 <title>GAP (";
 
-GAPDoc2HTMLProcs.MathJaxURL := "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+GAPDoc2HTMLProcs.MathJaxURL := "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
 
 GAPDoc2HTMLProcs.Head1MathJax := "\
 <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\


### PR DESCRIPTION
This is that last MathJax 2.x release and fixes a bunch of bugs
