### PR TITLE
Avoid more letters when constructing Verbatim's commandchars

### DIFF
--- a/lib/GAPDoc2LaTeX.gi
+++ b/lib/GAPDoc2LaTeX.gi
@@ -978,7 +978,10 @@ GAPDoc2LaTeXProcs.ExampleLike := function(r, str, label, findprompts)
   if findprompts then
     comchars := "";
     for c in Concatenation("!@|", LETTERS) do
-      if not c in cont then
+      if not c in cont and
+         not c in "Verbatim" and
+         not c in "gapinput" and
+         not c in "gapbrkprompt" then
         Add(comchars, c);
         if Length(comchars) = 3 then
           break;


### PR DESCRIPTION
For example, if the letter 'V' is chosen, this causes an error in the `\end{Verbatim}` line.