### PR TITLE
fix references with underscores

### DIFF
--- a/lib/GAPDoc2LaTeX.gi
+++ b/lib/GAPDoc2LaTeX.gi
@@ -1247,7 +1247,7 @@ GAPDoc2LaTeXProcs.Ref := function(r, str)
     # delete ref, if pointing to current subsection
     if not IsBound(r.attributes.BookName) and 
                  IsBound(GAPDoc2LaTeXProcs._currentSubsection) and 
-                 lab in GAPDoc2LaTeXProcs._currentSubsection then
+                 GAPDoc2LaTeXProcs.DeleteUsBs(lab) in GAPDoc2LaTeXProcs._currentSubsection then
       ref := "";
     fi;
     Append(str, Concatenation("\\texttt{", GAPDoc2LaTeXProcs.EscapeAttrVal(txt), 


### PR DESCRIPTION
When a reference points to a variable in the same subsection, the section number shall not be part of the reference.
If the variable name contains an underscore, this was not the case up to now, for the LaTeX version.