### PR TITLE
Stop using InfoData, always use InfoOutput

### DIFF
--- a/init.g
+++ b/init.g
@@ -10,18 +10,8 @@
 # An alternative Info handler which does not print implicit "#I " and "\n"
 BindGlobal("PlainInfoHandler",
 function ( infoclass, level, list )
-    local cl, out, s, infoOutput;
-    if IsBoundGlobal("InfoOutput") then
-      infoOutput := ValueGlobal("InfoOutput");
-      out := infoOutput(infoclass);
-    else
-      cl := InfoData.LastClass![1];
-      if IsBound(InfoData.Output[cl]) then
-        out := InfoData.Output[cl];
-      else
-        out := DefaultInfoOutput;
-      fi;
-    fi;
+    local cl, out, s;
+    out := InfoOutput(infoclass);
     if out = "*Print*" then
       for s in list do
         Print(s);


### PR DESCRIPTION
InfoOutput was added in GAP 4.9, and InfoData did not do anything since GAP 4.10
