### PR TITLE
make it testable whether errors occur

### DIFF
--- a/init.g
+++ b/init.g
@@ -25,6 +25,15 @@ function ( infoclass, level, list )
     fi;
 end);
 
+BindGlobal("GAPDocFailure",
+function( arg )
+    local opt;
+    opt := ValueOption("GAPDocCollectErrors");
+    if IsList(opt) and IsMutable(opt) then
+      Add(opt, Concatenation(List(arg, String)));
+    fi;
+end);
+
 ReadPackage("GAPDoc", "lib/UnicodeTools.gd");
 ReadPackage("GAPDoc", "lib/PrintUtil.gd");
 ReadPackage("GAPDoc", "lib/Text.gd");

--- a/lib/ComposeXML.gi
+++ b/lib/ComposeXML.gi
@@ -119,6 +119,8 @@ InstallGlobalFunction(ComposedDocument, function(arg)
     if str = fail then
       Info(InfoGAPDoc, 1, "#W WARNING: no file ", fname, 
                           " to compose document.\n");
+      GAPDocFailure("#W WARNING: no file ", fname,
+                          " to compose document.\n");
       continue;
     fi;
     posnl := Positions(str, '\n');
@@ -162,6 +164,11 @@ InstallGlobalFunction(ComposedDocument, function(arg)
       Info(InfoGAPDoc, 3, "Found piece ", name, "\n");
       if IsBound(pieces.(name)) then
         Info(InfoGAPDoc, 1, "#W WARNING: overwriting piece with label \"",
+             name,"\"\n#W   Previous occurrence: ",origin.(name)[1],
+             " line ", origin.(name)[2],"\n",
+             "#W   New occurrence: ",fname," line ",PositionSorted(posnl,
+             i+1),"\n");
+        GAPDocFailure("#W WARNING: overwriting piece with label \"",
              name,"\"\n#W   Previous occurrence: ",origin.(name)[1],
              " line ", origin.(name)[2],"\n",
              "#W   New occurrence: ",fname," line ",PositionSorted(posnl,

--- a/lib/GAPDoc.gi
+++ b/lib/GAPDoc.gi
@@ -677,6 +677,8 @@ BindGlobal("GAPDocAddBibData", function(r)
   if Length(diff) > 0 then
     Info(InfoGAPDoc, 1, "#W WARNING: could not find these references: \n", 
                                                          diff, "\n");
+    GAPDocFailure("#W WARNING: could not find these references: \n",
+                                                         diff, "\n");
   fi;
   r.bibkeys := keys;
   r.biblabels := labels;
@@ -773,6 +775,8 @@ InstallGlobalFunction(SetGapDocLanguage, function(arg)
   lang := LowercaseString(lang);
   if not IsBound(GAPDocTexts.(lang)) then
     Info(InfoGAPDoc, 1, "#W No texts in language ", lang, " available - ",
+                         "using English.\n");
+    GAPDocFailure("#W No texts in language ", lang, " available - ",
                          "using English.\n");
     Info(InfoGAPDoc, 1, "#W Please, provide translation of GAPDocTexts.",
                           "english in GAPDocTexts.", lang, ".\n");

--- a/lib/GAPDoc2HTML.gi
+++ b/lib/GAPDoc2HTML.gi
@@ -525,6 +525,7 @@ InstallGlobalFunction(GAPDoc2HTML, function(arg)
   if not IsBound(GAPDoc2HTMLProcs.(name)) then
     Info(InfoGAPDoc, 1, "#W WARNING: Don't know how to process element ", name, 
           " ---- ignored\n");
+    GAPDocFailure("#W WARNING: Don't know how to process element ", name, "\n");
   else
     GAPDoc2HTMLProcs.(r.name)(r, str);
   fi;
@@ -953,6 +954,7 @@ GAPDoc2HTMLProcs.URL := function(arg)
     rr := First(r.content, a-> a.name = "Link");
     if rr = fail then
       Info(InfoGAPDoc, 1, "#W missing <Link> element for text ", txt, "\n");
+      GAPDocFailure("#W missing <Link> element for text ", txt, "\n");
       s := "MISSINGLINK";
     else
       s := "";
@@ -1754,6 +1756,8 @@ GAPDoc2HTMLProcs.Ref := function(r, str)
       if GAPDoc2HTMLProcs.FirstRun <> true then
         Info(InfoGAPDoc, 1, "#W WARNING: non resolved reference: ",
                             r.attributes, "\n");
+        GAPDocFailure("#W WARNING: non resolved reference: ",
+                            r.attributes, "\n");
       fi;
       ref := Concatenation(rattr[1], "???", rattr[2]);
     fi;
@@ -1770,6 +1774,8 @@ GAPDoc2HTMLProcs.Ref := function(r, str)
     else
       if GAPDoc2HTMLProcs.FirstRun <> true then
         Info(InfoGAPDoc, 1, "#W WARNING: non resolved reference: ",
+                            r.attributes, "\n");
+        GAPDocFailure("#W WARNING: non resolved reference: ",
                             r.attributes, "\n");
       fi;
       ref := Concatenation(rattr[1], "???", rattr[2]);
@@ -1796,6 +1802,8 @@ GAPDoc2HTMLProcs.Ref := function(r, str)
     else
       if GAPDoc2HTMLProcs.FirstRun <> true then
         Info(InfoGAPDoc, 1, "#W WARNING: non resolved reference: ",
+                            r.attributes, "\n");
+        GAPDocFailure("#W WARNING: non resolved reference: ",
                             r.attributes, "\n");
       fi;
       txt := Concatenation(rattr[1], "???", rattr[2]);

--- a/lib/GAPDoc2LaTeX.gi
+++ b/lib/GAPDoc2LaTeX.gi
@@ -125,6 +125,7 @@ InstallGlobalFunction(GAPDoc2LaTeX, function(arg)
   if not IsBound(GAPDoc2LaTeXProcs.(name)) then
     Info(InfoGAPDoc, 1, "#W WARNING: Don't know how to process element ", name, 
           " ---- ignored\n");
+    GAPDocFailure("#W WARNING: Don't know how to process element ", name, "\n");
   else
     GAPDoc2LaTeXProcs.(r.name)(r, str);
   fi;
@@ -655,6 +656,7 @@ GAPDoc2LaTeXProcs.URL := function(arg)
     rr := First(r.content, a-> a.name = "Link");
     if rr = fail then
       Info(InfoGAPDoc, 1, "#W missing <Link> element for text ", txt, "\n");
+      GAPDocFailure("#W missing <Link> element for text ", txt, "\n");
       s := "MISSINGLINK";
     else
       s := "";
@@ -1233,6 +1235,8 @@ GAPDoc2LaTeXProcs.Ref := function(r, str)
       if ref = fail then
         Info(InfoGAPDoc, 1, "#W WARNING: non resolved reference: ",
                             r.attributes, "\n");
+        GAPDocFailure("#W WARNING: non resolved reference: ",
+                            r.attributes, "\n");
         ref := Concatenation(" (", Encode(Unicode(lab),
                GAPDoc2LaTeXProcs.Encoder)
                , "???)");
@@ -1271,6 +1275,8 @@ GAPDoc2LaTeXProcs.Ref := function(r, str)
       if ref = fail then
         Info(InfoGAPDoc, 1, "#W WARNING: non resolved reference: ",
                             r.attributes, "\n");
+        GAPDocFailure("#W WARNING: non resolved reference: ",
+                            r.attributes, "\n");
         ref := Concatenation(" (", lab, "???)");
       else
         # the search text for online help including book name
@@ -1282,6 +1288,8 @@ GAPDoc2LaTeXProcs.Ref := function(r, str)
                 GAPDoc2LaTeXProcs._labeledSections.(lab), WHITESPACE), "'}"); 
       else
         Info(InfoGAPDoc, 1, "#W WARNING: non resolved reference: ",
+                            r.attributes, "\n");
+        GAPDocFailure("#W WARNING: non resolved reference: ",
                             r.attributes, "\n");
         ref := "`???'";
       fi;
@@ -1306,6 +1314,8 @@ GAPDoc2LaTeXProcs.Ref := function(r, str)
                                         r.attributes.BookName, lab, 1);
     if ref = fail then
       Info(InfoGAPDoc, 1, "#W WARNING: non resolved reference: ",
+                            r.attributes, "\n");
+      GAPDocFailure("#W WARNING: non resolved reference: ",
                             r.attributes, "\n");
       ref := Concatenation(" ", GAPDoc2LaTeXProcs.EscapeAttrVal(lab), "??? ");
     else

--- a/lib/GAPDoc2Text.gi
+++ b/lib/GAPDoc2Text.gi
@@ -376,6 +376,7 @@ InstallGlobalFunction(GAPDoc2Text, function(arg)
   if not IsBound(GAPDoc2TextProcs.(name)) then
     Info(InfoGAPDoc, 1, "#W WARNING: Don't know how to process element ", name, 
           " ---- ignored\n");
+    GAPDocFailure("#W WARNING: Don't know how to process element ", name, "\n");
   else
     GAPDoc2TextProcs.(r.name)(r, str);
   fi;
@@ -834,6 +835,7 @@ GAPDoc2TextProcs.URL := function(arg)
     rr := First(r.content, a-> a.name = "Link");
     if rr = fail then
       Info(InfoGAPDoc, 1, "#W missing <Link> element for text ", txt, "\n");
+      GAPDocFailure("#W missing <Link> element for text ", txt, "\n");
       s := "MISSINGLINK";
     else
       s := "";
@@ -1509,6 +1511,8 @@ GAPDoc2TextProcs.Ref := function(r, str)
         if GAPDoc2TextProcs.FirstRun <> true then
           Info(InfoGAPDoc, 1, "#W WARNING: non resolved reference: ",
                             r.attributes, "\n");
+          GAPDocFailure("#W WARNING: non resolved reference: ",
+                            r.attributes, "\n");
         fi;
         ref := Concatenation(lab, "???");
       else
@@ -1521,6 +1525,8 @@ GAPDoc2TextProcs.Ref := function(r, str)
       else
         if GAPDoc2TextProcs.FirstRun <> true then
           Info(InfoGAPDoc, 1, "#W WARNING: non resolved reference: ",
+                            r.attributes, "\n");
+          GAPDocFailure("#W WARNING: non resolved reference: ",
                             r.attributes, "\n");
         fi;
         ref := Concatenation("???", lab, "???");
@@ -1553,6 +1559,8 @@ GAPDoc2TextProcs.Ref := function(r, str)
         if GAPDoc2TextProcs.FirstRun <> true then
           Info(InfoGAPDoc, 1, "#W WARNING: non resolved reference: ",
                             r.attributes, "\n");
+          GAPDocFailure("#W WARNING: non resolved reference: ",
+                            r.attributes, "\n");
         fi;
         ref := Concatenation(lab, "???");
       else
@@ -1573,6 +1581,8 @@ GAPDoc2TextProcs.Ref := function(r, str)
       else
         if GAPDoc2TextProcs.FirstRun <> true then
           Info(InfoGAPDoc, 1, "#W WARNING: non resolved reference: ",
+                            r.attributes, "\n");
+          GAPDocFailure("#W WARNING: non resolved reference: ",
                             r.attributes, "\n");
         fi;
         ref := Concatenation("???", lab, "???");

--- a/lib/Make.g
+++ b/lib/Make.g
@@ -61,6 +61,7 @@ BindGlobal("MakeGAPDocDoc", function(path, main, files, bookname, opts...)
     if Filename(DirectoriesSystemPrograms(), "pdflatex") = fail then
       Info(InfoGAPDoc, 1, "\n#W WARNING: cannot find 'pdflatex', please install TeX.\n");
       Info(InfoGAPDoc, 1, "#W WARNING: will NOT produce pdf version from LaTeX file.\n");
+      GAPDocFailure("#W WARNING: cannot find 'pdflatex', please install TeX.\n");
     else
       # call latex and pdflatex (with bibtex, makeindex and dvips)
       latex := "latex -interaction=nonstopmode ";
@@ -81,6 +82,8 @@ BindGlobal("MakeGAPDocDoc", function(path, main, files, bookname, opts...)
       if log = fail then
         Info(InfoGAPDoc, 1, "\n#W WARNING: Something wrong, don't find log file ",
                               Filename(path, Concatenation(main, ".log")), "\n");
+        GAPDocFailure("#W WARNING: Something wrong, don't find log file ",
+                              Filename(path, Concatenation(main, ".log")), "\n");
       else
         log := SplitString(log, "\n", "");
         pos := Filtered([1..Length(log)], i-> Length(log[i]) > 0 
@@ -93,6 +96,7 @@ BindGlobal("MakeGAPDocDoc", function(path, main, files, bookname, opts...)
             od;
             Info(InfoGAPDoc, 1, "____________________\n");
           od;
+          GAPDocFailure("#W There were LaTeX errors\n");
         fi;
         pos := Filtered([1..Length(log)], i-> Length(log[i]) > 13 
                                          and log[i]{[1..14]} = "LaTeX Warning:");

--- a/lib/XMLParser.gi
+++ b/lib/XMLParser.gi
@@ -242,6 +242,9 @@ InstallGlobalFunction(GetEnt, function(str, pos)
     Info(InfoXMLParser, 1, "#W WARNING: Entity with name `", nam, 
              "' not known!\n#W", "        (Specify in <!DOCTYPE ...> tag or ",
              "in argument to parser!)\n");
+    GAPDocFailure("#W WARNING: Entity with name `", nam,
+             "' not known!\n#W", "        (Specify in <!DOCTYPE ...> tag or ",
+             "in argument to parser!)\n");
     doc := Concatenation("UNKNOWNEntity(", nam, ")");
   else
     doc := ENTITYDICT.(nam);


### PR DESCRIPTION
GAPDoc tries to create manuals even if `MakeGAPDocDoc` notices errors, such as missing labels used in cross-references.
This is very good if one wants to produce some preliminary version of the manuals and then to improve them.
On the other hand, it is useful to detect programmatically whether errors occur, for example in automatic tests.

The current proposal
- adds support for the global option `GAPDocCollectErrors`; if the value of this option is a (mutable) list then information about errors that are noticed by `MakeGAPDocDoc` get added to this list,
- introduces an internal function `GAPDocFailure` that gets called in order to change the list of errors found; this happens in the relevant places where currently an `Info` message about an error gets printed.

Thus one can use the new feature as follows.
```
errs:= [];
MakeGAPDocDoc( ... : GAPDocCollectErrors:= errs );;
if Length( errs ) <> 0 then
  # call `Error( "..." )` or `GapExitCode( false )` or ...
fi;
```

Once this feature becomes available, it can be used in
- GAP's `doc/make_doc.g`
- the `makedoc.g` files of GAP packages that use GAPDoc,
- the `AutoDoc` calls of GAP packages that use AutoDoc.