### PR TITLE
Fix line height for authors on PDF title page

### DIFF
--- a/lib/GAPDoc2LaTeX.gi
+++ b/lib/GAPDoc2LaTeX.gi
@@ -496,13 +496,13 @@ GAPDoc2LaTeXProcs.TitlePage := function(r, str)
   # collect author list for PDF info
   ll := [];
   for a in l do
-    Append(str, "{\\Large \\textbf{");
+    Append(str, "{\\Large \\textbf{\\strut ");
     s := "";
     GAPDoc2LaTeXContent(rec(content := Filtered(a.content, b->
                    not b.name in ["Email", "Homepage", "Address"])), s);
     Append(str, s);
     Add(ll, s);
-    Append(str, "\\mbox{}}}\\\\\n");
+    Append(str, " \\strut\\mbox{}}}\\\\\n");
   od;
   Append(str, "\\hypersetup{pdfauthor=");
   Append(str, JoinStringsWithSeparator(ll, "; "));


### PR DESCRIPTION
UPDATE: the spacing issues in title and subtitle were fixed by @frankluebeck in 5122d04777a143b7d908c21892a17ee3251474c8 by different means (adding extra empty lines).

But for the spacing of author names, that doesn't seem appealing to me, the distance is too wide. I initially tried to use `\par` as describe below but that resulted in LaTeX warnings. Finally Codex found a working solution, which is no in this PR:

Use \strut around author names on the title page so multi-author
blocks get a more suitable line height in the PDF output.

Old text follows:

----


... due to insufficient line spacing. The lines look "smushed together".

See also <https://tex.stackexchange.com/a/183710/1755> for an explanation of the changes in this fix.

Before:

<img width="395" height="394" alt="Screenshot 2025-11-13 at 01 10 23" src="https://github.com/user-attachments/assets/7f9473cd-2cac-4989-b040-e373387dc712" />

After:
<img width="382" height="484" alt="Screenshot 2025-11-13 at 01 10 59" src="https://github.com/user-attachments/assets/fcca9da0-9025-4c40-af2f-aab75f7bc002" />
