### PR TITLE
Add dark mode support

### DIFF
--- a/styles/chooser.html
+++ b/styles/chooser.html
@@ -23,9 +23,18 @@ function currval(nam) {
   return "";
 }
 
+<!-- load dark appearance either explicitly or via the OS preference -->
+function writeAppearanceStyle(mode) {
+  if (mode == "dark") {
+    document.writeln('<link rel="stylesheet" type="text/css" href="dark.css" />');
+  } else if (mode != "light") {
+    document.writeln('<style type="text/css">@import "dark.css" (prefers-color-scheme: dark);</style>');
+  }
+}
+
 <!-- find style from current values in form -->
 function getstyle() {
-  var choices = ["toggle","colorprompt","tocside","font","justify"]; 
+  var choices = ["toggle","colorprompt","tocside","font","justify","appearance"];
   var style = "";
   for (var i=0; choices.length > i; i++) {
     var a = currval(choices[i]);
@@ -55,17 +64,23 @@ function resetf() {
 <!-- initialize form from GAPDocStyle cookie -->
 function initform() {
   var style = valueString(document.cookie, "GAPDocStyle");
+  if (style == 0 || style == "default")
+    writeAppearanceStyle("");
   if (style != 0 && style.length > 0 && style.length != "default") {
     stlist = style.split(",");
     var chform = document.forms[0].elements;
+    var appearance = "";
     for (var i=0; chform.length > i; i++) {
       if (chform[i].type == "radio") {
         for (var j=0; stlist.length > j; j++) {
-          if (chform[i].value == stlist[j]) 
+          if (stlist[j] == "dark" || stlist[j] == "light")
+            appearance = stlist[j];
+          if (chform[i].value == stlist[j])
             chform[i].checked = true;
         }
       }
     }
+    writeAppearanceStyle(appearance);
   }
 }
 
@@ -118,6 +133,15 @@ onclick="javascript:f()"/> left-right
 justified (default) &nbsp;&nbsp;&nbsp;
 <input type="radio" name="justify" value="ragged"
 onclick="javascript:f()"/> ragged right 
+</p>
+<p>
+Appearance:
+<input type="radio" name="appearance" value="" checked="checked"
+onclick="javascript:f()"/> system (default) &nbsp;&nbsp;&nbsp;
+<input type="radio" name="appearance" value="light"
+onclick="javascript:f()"/> light
+<input type="radio" name="appearance" value="dark"
+onclick="javascript:f()"/> dark
 </p>
 </form>
 <p>

--- a/styles/dark.css
+++ b/styles/dark.css
@@ -49,36 +49,40 @@ div.example {
 
 /* Links to chapters in all files at top and bottom. */
 div.chlinktop {
-  background: #b5b5b5;
-  color: black;
+  background: #22272e;
+  border-color: #3a414a;
+  color: #d7dde5;
 }
 
 div.chlinktop a:hover {
-  background: #fff;
+  background: #2f3742;
 }
 
 div.chlinkbot {
-  background: #b5b5b5;
-  color: black;
+  background: #22272e;
+  border-color: #3a414a;
+  color: #d7dde5;
 }
 
 /* and this is for the "Top", "Prev", "Next" links */
 div.chlinkprevnexttop {
-  background: #b5b5b5;
-  color: black;
+  background: #22272e;
+  border-color: #3a414a;
+  color: #d7dde5;
 }
 
 div.chlinkprevnexttop a:hover {
-  background: #fff;
+  background: #2f3742;
 }
 
 div.chlinkprevnextbot {
-  background: #b5b5b5;
-  color: black;
+  background: #22272e;
+  border-color: #3a414a;
+  color: #d7dde5;
 }
 
 div.chlinkprevnextbot a:hover {
-  background: #fff;
+  background: #2f3742;
 }
 
 div.ContChap div.ContSect:hover div.ContSSBlock {

--- a/styles/dark.css
+++ b/styles/dark.css
@@ -1,0 +1,174 @@
+/* dark.css                                             Frank Luebeck */
+/* Initial dark theme contributed by kiryph in issue #75.            */
+
+/* colors */
+body {
+  background: #121212;
+  color: #eee;
+}
+
+a:link {
+  color: #576cad;
+}
+
+a:visited {
+  color: #576cad;
+}
+
+a:active {
+  color: #eee;
+}
+
+a:hover {
+  background: #eee;
+}
+
+pre {
+  color: black;
+}
+
+tt, code {
+  color: #eee;
+}
+
+/* layout for the definitions of functions, variables, ... */
+div.func {
+  background: #909090;
+}
+
+/* Example elements (for old converted manuals, now in div+pre */
+table.example {
+  background: #efefef;
+}
+
+/* becomes ... */
+div.example {
+  background: #efefef;
+  color: black;
+}
+
+/* Links to chapters in all files at top and bottom. */
+div.chlinktop {
+  background: #b5b5b5;
+  color: black;
+}
+
+div.chlinktop a:hover {
+  background: #fff;
+}
+
+div.chlinkbot {
+  background: #b5b5b5;
+  color: black;
+}
+
+/* and this is for the "Top", "Prev", "Next" links */
+div.chlinkprevnexttop {
+  background: #b5b5b5;
+  color: black;
+}
+
+div.chlinkprevnexttop a:hover {
+  background: #fff;
+}
+
+div.chlinkprevnextbot {
+  background: #b5b5b5;
+  color: black;
+}
+
+div.chlinkprevnextbot a:hover {
+  background: #fff;
+}
+
+div.ContChap div.ContSect:hover div.ContSSBlock {
+  background: #eee;
+  border-color: #666;
+  color: #000;
+}
+
+div.ContSSBlock a:hover {
+  background: #fff;
+}
+
+/* and here for the side menu of contents in the chapter files */
+div.ChapSects a:hover {
+  background: #eee;
+  color: #000;
+}
+
+div.ChapSects div.ContSect:hover div.ContSSBlock {
+  background: #b5b5b5;
+  border-color: #666;
+  color: #000;
+}
+
+div.ChapSects div.ContSect:hover div.ContSSBlock a:hover {
+  background: #828282;
+}
+
+/* Table elements */
+table.GAPDocTable {
+  border-color: black;
+}
+
+table.GAPDocTable td, table.GAPDocTable th {
+  border-color: #555;
+}
+
+table.GAPDocTablenoborder td, table.GAPDocTable th {
+  border-color: #555;
+}
+
+/* Colors and fonts can be overwritten for some types of elements. */
+/* Verb elements */
+pre.normal {
+  color: #eee;
+}
+
+/* Func-like elements and Ref to Func-like */
+code.func {
+  color: #eee;
+}
+
+/* K elements */
+code.keyw {
+  color: #983d3d;
+}
+
+/* F elements */
+code.file {
+  color: #8e4510;
+}
+
+/* Arg elements */
+var.Arg {
+  color: #060;
+}
+
+/* colors for ColorPrompt like examples */
+span.GAPprompt {
+  color: #000097;
+}
+
+span.GAPbrkprompt {
+  color: #970000;
+}
+
+span.GAPinput {
+  color: #970000;
+}
+
+/* Bib entries */
+span.BibKey {
+  color: #052;
+}
+
+/* for light and dark mode pictures */
+.only-on-dark {
+  display: block;
+}
+
+.only-on-light {
+  display: none;
+}

--- a/styles/manual.css
+++ b/styles/manual.css
@@ -477,6 +477,10 @@ span.BibNote {
 span.BibHowpublished {
 }
 
+/* for light and dark mode pictures */
+.only-on-dark {
+  display: none;
+}
 
 
 

--- a/styles/manual.js
+++ b/styles/manual.js
@@ -47,6 +47,20 @@ function valueString(str,nam) {
   return 0;
 }
 
+/* load dark appearance either explicitly or via the OS preference */
+function writeAppearanceStyle(mode) {
+  if (mode == "dark") {
+    document.writeln(
+      '<link rel="stylesheet" type="text/css" href="dark.css" />'
+    );
+  } else if (mode != "light") {
+    document.writeln(
+      '<style type="text/css">@import "dark.css" ' +
+      '(prefers-color-scheme: dark);</style>'
+    );
+  }
+}
+
 /* when a non-default style is chosen via URL or a cookie, then
    the cookie is reset and the styles .js and .css files are read  */
 function overwriteStyle() {
@@ -55,6 +69,8 @@ function overwriteStyle() {
   /* otherwise check cookie */
   if (style == 0)
     style = valueString(document.cookie, "GAPDocStyle");
+  if (style == 0 || style == "default")
+    writeAppearanceStyle("");
   if (style == 0)
     return;
   if (style == "default")
@@ -70,13 +86,19 @@ function overwriteStyle() {
     document.cookie = "GAPDocStyle="+style+";Path="+path;
     /* split into names of style files */
     var stlist = style.split(",");
+    var appearance = "";
     /* read style's css and js files */
     for (var i=0; i < stlist.length; i++) {
-      document.writeln('<link rel="stylesheet" type="text/css" href="'+
-                                                         stlist[i]+'.css" />');
-      document.writeln('<script src="'+stlist[i]+
-                                      '.js" type="text/javascript"></script>');
+      if (stlist[i] == "dark" || stlist[i] == "light") {
+        appearance = stlist[i];
+      } else {
+        document.writeln('<link rel="stylesheet" type="text/css" href="'+
+                                                           stlist[i]+'.css" />');
+        document.writeln('<script src="'+stlist[i]+
+                                        '.js" type="text/javascript"></script>');
+      }
     }
+    writeAppearanceStyle(appearance);
   }
 }
 
@@ -110,4 +132,3 @@ function jscontent () {
   for (var i=0; i < jscontentfuncs.length; i++)
     jscontentfuncs[i]();
 }
-


### PR DESCRIPTION
Resolves #75

I took the work done by @kiryph on that PR (or rather, asked Codex to import it -- this is the first commit), and then asked the AI to tweak the light gray horizontal bars (the contrast was too strong for my liking -- this is the second commit).

Result:
<img width="784" height="702" alt="Screenshot 2026-03-13 at 13 08 45" src="https://github.com/user-attachments/assets/80c4a4ad-c12d-4edc-8c42-f552040cf887" />
