### PR TITLE
Add `Dependencies.NeededSystemPackages` in `PackageInfo.g`

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -75,6 +75,9 @@ Dependencies := rec(
   GAP := "4.11.0",
   NeededOtherPackages := [],
   SuggestedOtherPackages := [["IO", ">= 4.7"]],
+  NeededSystemPackages := rec(
+    Ubuntu := [["texlive"], ["texlive-latex-extra"]]
+  ),
   ExternalConditions := 
             ["(La)TeX installation for converting documents to PDF",
               "BibTeX installation to produce unified labels for refs",


### PR DESCRIPTION
This would help with CI scripts and the package distribution.

Remarks:
 - I used `texlive` instead of `texlive-latex-base`, `texlive-latex-recommended` and `texlive-fonts-recommended` to keep things simple. The former package is essentially just a wrapper for the latter three.
 - Should the default bib style change to `alphaurl` instead of `alpha` (as suggested in https://github.com/frankluebeck/GAPDoc/issues/81), then `texlive-bibtex-extra` should probably be added as well.