### PR TITLE
dx.doi.org is deprecated and has been for years

### DIFF
--- a/lib/BibTeX.gi
+++ b/lib/BibTeX.gi
@@ -925,7 +925,7 @@ InstallGlobalFunction(StringBibAsHTML, function(arg)
   fi;
   if IsBound(r.doi) then
     Append(res, Concatenation(",\n<span class='BibDOI'> (<a href=\"", 
-                "http://dx.doi.org/",
+                "https://doi.org/",
                 r.doi, "\">", r.doi,"</a>)</span>"));
   fi;
   # a private extension of the author
@@ -1107,7 +1107,7 @@ InstallGlobalFunction(StringBibAsText, function(arg)
         txt(field);
         continue;
       elif field = "doi" then
-        Append(str, " (http://dx.doi.org/");
+        Append(str, " (https://doi.org/");
         txt(field);
         Append(str, ")");
         continue;
@@ -1317,7 +1317,7 @@ InstallGlobalFunction(StringBibAsMarkdown, function( arg )
         Append(str, " "); 
         txt(field);
       elif field = "doi" then
-        Append(str, " (http://dx.doi.org/");
+        Append(str, " (https://doi.org/");
         txt(field);
         Append(str, ")");
         continue;


### PR DESCRIPTION
To quote section 5.3.1 "DOI Proxy" of the [DOI Handbook](https://www.doi.org/doi-handbook/html/index.html):

> An earlier proxy address (https://dx.doi.org) is deprecated and its use is discouraged.

Moreover, https should be used instead of http (all examples and references in the DOI Handbook and in general in material by the DOI Foundation does so).