### PR TITLE
Stop offering a -win.zip file

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -21,7 +21,7 @@ SourceRepository := rec(
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
 ArchiveURL := 
           "https://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/GAPDoc-1.6.10",
-ArchiveFormats := ".tar.bz2 .tar.gz -win.zip",
+ArchiveFormats := ".tar.bz2 .tar.gz",
 Persons := [
   rec(
   LastName := "Lübeck",

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ installation. The archive is available in several formats:
 
   - `GAPDoc-XXX.tar.gz`  (GNU tar archive, gzip'ed)
   - `GAPDoc-XXX.tar.bz2` (GNU tar archive, bzip2'ed)
-  - `GAPDoc-XXX-win.zip` (with DOS/Windows style line breaks in text files)
 
 Unpacking generates a subdirectory of form `GAPDoc-x.y.z`. 
 

--- a/index.html
+++ b/index.html
@@ -248,10 +248,6 @@
   <a href="GAPDoc-1.6.10.tar.bz2"><code>GAPDoc-1.6.10.tar.bz2</code></a>  
   (GNU <code>tar</code> archive, <code>bzip2</code>'ed)
   </li>
-  <li>
-  <a href="GAPDoc-1.6.10-win.zip"><code>GAPDoc-1.6.10-win.zip</code></a>  
-  (with DOS/Windows style line breaks in text files)
-  </li>
   </ul>
 
 

--- a/toweb
+++ b/toweb
@@ -5,7 +5,7 @@ echo "Is ./index.html updated (Version, subdir, archive names, last updated)?"
 echo "Copying files to this web directory, is that ok?"
 echo "       "$WEBDIR
 echo "Assuming that in this directory exist archives "
-echo "       "GAPDoc-`cat version`"{.tar.bz2,,tar.gz,-win.zip}"
+echo "       "GAPDoc-`cat version`"{.tar.bz2,,tar.gz}"
 
 echo "Shall I start (y/N)?"
 read -n 1 -p "-->" start
@@ -77,7 +77,7 @@ echo copying index.html and pkgreadme.css . . .
 cp index.html pkgreadme.css $WEBDIR
 
 echo copying archives . . .
-cp GAPDoc-`cat version`{.tar.bz2,.tar.gz,-win.zip} $WEBDIR
+cp GAPDoc-`cat version`{.tar.bz2,.tar.gz} $WEBDIR
 
 echo "creating SERVE files (maybe restart server)"
 cd $WEBDIR


### PR DESCRIPTION
only two packages still do that; GAPDoc and EDIM.

---

Of course this also doesn't hurt, it'll just be ignored by
more or less everyone and everything. But if you prefer to
keep it, also OK.
